### PR TITLE
setup: fix virtual environment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,8 @@ trim_trailing_whitespace = true
 [*.md]
 indent_size = 2
 indent_style = space
-max_line_length = 100  # Please keep this in sync with bin/lesson_check.py!
+# Please keep max_line_length in sync with bin/lesson_check.py!
+max_line_length = 100
 
 [*.r]
 max_line_length = 80

--- a/_episodes/02-first-example.md
+++ b/_episodes/02-first-example.md
@@ -214,11 +214,8 @@ Options:
 The REANA client will interact with a remote REANA cluster. It knows to which REANA cluster it connects by means of the following environment variable:
 
 ```bash
-$ source /afs/cern.ch/user/r/reana/public/bin/reana/activate/
 $ export REANA_SERVER_URL=https://reana.cern.ch
 ```
-
-The source command is for lxplus users only.
 
 In order to authenticate to REANA, you need to generate a token.
 

--- a/setup.md
+++ b/setup.md
@@ -10,21 +10,33 @@ This lesson teaches the principles of containerised scientific workflows by mean
 The participants should either install [reana-client](https://pypi.org/project/reana-client/) on
 their laptops:
 
+~~~bash
+virtualenv ~/.virtualenvs/reana
+source ~/.virtualenvs/reana/bin/activate
+pip install reana-client
 ~~~
-$ virtualenv ~/.virtualenvs/reana
-$ source ~/.virtualenvs/reana/bin/activate
-$ pip install --pre reana-client
-~~~
-{: .bash}
+{: .source}
 
-Alternatively, the participants can log into CERN's LXPLUS cluster and use a pre-existing
-environment there:
+Alternatively, the participants can log into CERN's LXPLUS cluster using `ssh lxplus.cern.ch` and
+activate a pre-existing environment there:
+
+~~~bash
+source /afs/cern.ch/user/r/reana/public/reana/bin/activate
+~~~
+{: .source}
+
+After installation of `reana-client`, please check whether the client works by asking for its
+version:
+
+~~~bash
+reana-client version
+~~~
+{: .source}
 
 ~~~
-$ ssh lxplus.cern.ch
-lxplus> source ~simko/public/reana/bin/activate
+0.9.1
 ~~~
-{: .bash}
+{: .output}
 
 ---
 


### PR DESCRIPTION
Uses production version of `reana-client` that is now sufficient.

Uses production virtual environment on LXPLUS instead of personal one.

Fixes virtual environment activation commands.