### PR TITLE
episode2: fix content for REANA 0.9.1

### DIFF
--- a/_episodes/02-first-example.md
+++ b/_episodes/02-first-example.md
@@ -38,12 +38,13 @@ We shall get acquainted with REANA by means of running a sample analysis example
 Let's start by cloning it:
 
 ```bash
-$ git clone https://github.com/reanahub/reana-demo-root6-roofit
-$ cd reana-demo-root6-roofit
+git clone https://github.com/reanahub/reana-demo-root6-roofit
+cd reana-demo-root6-roofit
 ```
+{: .source}
 
 What does the example do? The example emulates a typical particle physics analysis where the signal
-and background data is processed and fitted against a model. The example will use the
+and background data is processed and fitted against a model. The example uses the
 [RooFit](https://root.cern/manual/roofit/) package of the [ROOT](https://root.cern.ch/) framework.
 
 Four questions:
@@ -79,11 +80,11 @@ Workflow definition:
             V
            STOP
 ```
+{: .output}
 
 The four questions expressed in ``reana.yaml`` fully define our analysis:
 
 ```yaml
-version: 0.6.0
 inputs:
   files:
     - code/gendata.C
@@ -97,20 +98,35 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         commands:
         - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png
 ```
+{: .source}
 
-Note the basic structure of `reana.yaml` answering the Four Questions. (input data? analysis code?
-compute environment? workflow steps?)
+Note the basic structure of `reana.yaml` answering the Four Questions. (Where is input data? Where
+is analysis code? What compute environment to use? What are the computational steps to arrive at
+results?)
+
+> ## Exercise
+>
+> Familiarise yourself with the RooFit demo example by studying the README file and looking at the
+> `gendata.C` and `fitdata.C` source code.
+{: .challenge}
+
+> ## Solution
+> ```bash
+> firefox https://github.com/reanahub/reana-demo-root6-roofit
+> ```
+> {: .source}
+{: .solution}
 
 ## First steps with the REANA command-line client
 
@@ -120,10 +136,11 @@ you haven't already installed it.
 The client will offer several commands which we shall go through in this tutorial:
 
 ```bash
-$ reana-client --help
+reana-client --help
 ```
+{: .source}
 
-```output
+```
 Usage: reana-client [OPTIONS] COMMAND [ARGS]...
 
   REANA client for interacting with REANA server.
@@ -133,7 +150,11 @@ Options:
                                   Sets log level
   --help                          Show this message and exit.
 
+Quota commands:
+  quota-show  Show user quota.
+
 Configuration commands:
+  info     List cluster general information.
   ping     Check connection to REANA server.
   version  Show version.
 
@@ -161,27 +182,33 @@ Workspace file management commands:
   du        Get workspace disk usage.
   ls        List workspace files.
   mv        Move files within workspace.
+  prune     Prune workspace files.
   rm        Delete files from workspace.
   upload    Upload files and directories to workspace.
+
+Workspace file retention commands:
+  retention-rules-list  List the retention rules for a workflow.
 
 Secret management commands:
   secrets-add     Add secrets from literal string or from file.
   secrets-delete  Delete user secrets by name.
   secrets-list    List user secrets.
 ```
+{: .output}
 
 You can use ``--help`` option to learn more about any command, for example ``validate``:
 
 ```bash
-$ reana-client validate --help
+reana-client validate --help
 ```
+{: .source}
 
-```output
+```
 Usage: reana-client validate [OPTIONS]
 
   Validate workflow specification file.
 
-  The `validate` command allows to check syntax and validate the reana.yaml
+  The ``validate`` command allows to check syntax and validate the reana.yaml
   workflow specification file.
 
   Examples:
@@ -189,10 +216,20 @@ Usage: reana-client validate [OPTIONS]
        $ reana-client validate -f reana.yaml
 
 Options:
-  -f, --file PATH  REANA specifications file describing the workflow and
-                   context which REANA should execute.
-  --help           Show this message and exit.
+  -f, --file PATH          REANA specification file describing the workflow to
+                           execute. [default=reana.yaml]
+  --environments           If set, check all runtime environments specified in
+                           REANA specification file. [default=False]
+  --pull                   If set, try to pull remote environment image from
+                           registry to perform validation locally. Requires
+                           ``--environments`` flag. [default=False]
+  --server-capabilities    If set, check the server capabilities such as
+                           workspace validation. [default=False]
+  -t, --access-token TEXT  Access token of the current user.
+  --help                   Show this message and exit.
 ```
+{: .output}
+
 
 > ## Exercise
 >
@@ -201,44 +238,66 @@ Options:
 
 > ## Solution
 > ```bash
-> $ reana-client validate -f ./reana.yaml
+> reana-client validate
 > ```
+> {: .source}
 >
-> ```output
-> File reana-demo-root6-roofit/reana.yaml is a valid REANA specification file.
 > ```
+> ==> Verifying REANA specification file... reana.yaml
+>   -> SUCCESS: Valid REANA specification file.
+> ==> Verifying REANA specification parameters...
+>   -> SUCCESS: REANA specification parameters appear valid.
+> ==> Verifying workflow parameters and commands...
+>   -> SUCCESS: Workflow parameters and commands appear valid.
+> ==> Verifying dangerous workflow operations...
+>   -> SUCCESS: Workflow operations appear valid.
+> ```
+> {: .output}
 {: .solution}
 
 ## Connect REANA client to remote REANA cluster
 
-The REANA client will interact with a remote REANA cluster. It knows to which REANA cluster it connects by means of the following environment variable:
+The REANA client will interact with a remote REANA cluster. It knows to which REANA cluster it
+connects by means of the following environment variable:
 
 ```bash
-$ export REANA_SERVER_URL=https://reana.cern.ch
+export REANA_SERVER_URL=https://reana.cern.ch
 ```
+{: .source}
 
 In order to authenticate to REANA, you need to generate a token.
 
 > ## Exercise: Obtain a token.
->In order to set the token, go to https://reana.cern.ch to activate your REANA token.
+>In order to obtain your token, please go to https://reana.cern.ch and ask for it.
 {: .challenge}
 
 In your terminal, paste the line with your new access token as seen below.
 
 ```bash
-$ export REANA_ACCESS_TOKEN=xxxxxx
+export REANA_ACCESS_TOKEN=xxxxxx
 ```
+{: .source}
 
-It may be good to to create a `.sh` file to store these commands. That way you all you need to do to setup your environment is `source file.sh`. An alternative to this is opening up your `.bashrc` file and pasting these lines within there.
+It may be a good idea to create a `reana-setup-environment.sh` file to store these two export
+commands. That way you all you need to do to setup your environment is `source
+reana-setup-environment.sh`. An alternative to this is opening up your `.bashrc` file and pasting
+the above two export commands there.
 
 The REANA client connection to remote REANA cluster can be verified via ``ping`` command:
 
 ```bash
-$ reana-client ping
+reana-client ping
 ```
-```output
-Connected to https://reana.cern.ch - Server is running.
+{: .source}
+
 ```
+REANA server: https://reana.cern.ch
+REANA server version: 0.9.1
+REANA client version: 0.9.1
+Authenticated as: John Doe <john.doe@example.org>
+Status: Connected
+```
+{: .output}
 
 ## Run example on REANA cluster
 
@@ -246,18 +305,32 @@ Now that we have defined and validated our ``reana.yaml``, and connected to the 
 cluster, we can run the example easily via:
 
 ```bash
-$ reana-client run -w roofit
+reana-client run -w roofit
 ```
+{: .source}
 
-```output
-[INFO] Creating a workflow...
-roofit.1
-[INFO] Uploading files...
-File code/gendata.C was successfully uploaded.
-File code/fitdata.C was successfully uploaded.
-[INFO] Starting workflow...
-roofit.1 is running
 ```
+==> Creating a workflow...
+==> Verifying REANA specification file... reana.yaml
+  -> SUCCESS: Valid REANA specification file.
+==> Verifying REANA specification parameters...
+  -> SUCCESS: REANA specification parameters appear valid.
+==> Verifying workflow parameters and commands...
+  -> SUCCESS: Workflow parameters and commands appear valid.
+==> Verifying dangerous workflow operations...
+  -> SUCCESS: Workflow operations appear valid.
+==> Verifying compute backends in REANA specification file...
+  -> SUCCESS: Workflow compute backends appear to be valid.
+roofit.1
+==> SUCCESS: File /reana.yaml was successfully uploaded.
+==> Uploading files...
+==> Detected .gitignore file. Some files might get ignored.
+==> SUCCESS: File /code/gendata.C was successfully uploaded.
+==> SUCCESS: File /code/fitdata.C was successfully uploaded.
+==> Starting workflow...
+==> SUCCESS: roofit.1 is pending
+```
+{: .output}
 
 Here, we use ``run`` command that will create a new workflow named ``roofit``, upload its inputs as
 specified in the workflow specification and finally start the workflow.
@@ -265,36 +338,56 @@ specified in the workflow specification and finally start the workflow.
 While the workflow is running, we can enquire about its status:
 
 ```bash
-$ reana-client status -w roofit
+reana-client status -w roofit
 ```
+{: .source}
 
-```output
+```
 NAME     RUN_NUMBER   CREATED               STARTED               STATUS    PROGRESS
 roofit   1            2020-02-17T16:01:45   2020-02-17T16:01:48   running   1/2
 ```
+{: .output}
 
-After a minute, the workflow should finish and we can list the output files in the remote workspace:
+After a minute or so, the workflow should finish:
 
 ```bash
-$ reana-client ls -w roofit
+reana-client status -w roofit
 ```
+{: .source}
 
-```output
+```
+NAME     RUN_NUMBER   CREATED               STARTED               ENDED                 STATUS     PROGRESS
+roofit   1            2020-02-17T16:01:45   2020-02-17T16:01:48   2020-02-17T16:02:44   finished   2/2
+
+```
+{: .output}
+
+We can list the output files in the remote workspace:
+
+```bash
+reana-client ls -w roofit
+```
+{: .source}
+
+```
 NAME                SIZE     LAST-MODIFIED
+reana.yaml          687      2020-02-17T16:01:46
 code/gendata.C      1937     2020-02-17T16:01:46
 code/fitdata.C      1648     2020-02-17T16:01:47
 results/plot.png    15450    2020-02-17T16:02:44
 results/data.root   154457   2020-02-17T16:02:17
 ```
+{: .output}
 
-We can also get the logs:
+We can also inspect the logs:
 
 ```bash
-$ reana-client logs -w roofit | less
+reana-client logs -w roofit | less
 # (Hit q to quit 'less')
 ```
+{: .source}
 
-```output
+```
 ==> Workflow engine logs
 2020-02-17 16:02:10,859 | root | MainThread | INFO | Publishing step:0, cmd: mkdir -p results && root -b -q 'code/gendata.C(20000,"results/data.root")', total steps 2 to MQ
 2020-02-17 16:02:23,002 | root | MainThread | INFO | Publishing step:1, cmd: root -b -q 'code/fitdata.C("results/data.root","results/plot.png")', total steps 2 to MQ
@@ -311,13 +404,27 @@ $ reana-client logs -w roofit | less
 ==> Logs:
 ...
 ```
+{: .output}
+
 
 We can download the resulting plot:
 
 ```bash
-$ reana-client download results/plot.png -w roofit
-$ display results/plot.png
+reana-client download results/plot.png -w roofit
 ```
+{: .source}
+
+```
+==> SUCCESS: File results/plot.png downloaded to reana-demo-root6-roofit.
+```
+{: .output}
+
+And display it:
+
+```bash
+firefox results/plot.png
+```
+{: .source}
 
 <img src="{{ page.root }}/fig/reana-demo-root6-roofit-plot.png" width="400px" />
 
@@ -331,8 +438,9 @@ $ display results/plot.png
 > ## Solution
 >
 > ```bash
-> $ reana-client logs -w roofit --step gendata
+> $ reana-client logs -w roofit --filter step=gendata
 > ```
+> {: .source}
 {: .solution}
 
 {% include links.md %}


### PR DESCRIPTION
Updates content to fit the latest REANA 0.9.1 version commands.

Expands the content slightly by amending verbiage and introducing more details.

Fixes the bash/output example formatting to fit the latest carpentry style.