### PR TITLE
episode4: fix content for REANA 0.9.1

### DIFF
--- a/_episodes/04-higgstotautau-serial.md
+++ b/_episodes/04-higgstotautau-serial.md
@@ -81,8 +81,6 @@ With the above hits, please try to write workflow either individually or in pair
 > ## Solution
 >
 > ```yaml
-> $ cat reana.yaml
-> version: 0.6.0
 > inputs:
 >   parameters:
 >     eosdir: root://eospublic.cern.ch//eos/root-eos/HiggsTauTauReduced
@@ -110,6 +108,7 @@ With the above hits, please try to write workflow either individually or in pair
 >   files:
 >     - fitting/fit.png
 > ```
+> {: .output}
 {: .solution}
 
 {% include links.md %}

--- a/fig/awesome-analysis-serial/reana.yaml
+++ b/fig/awesome-analysis-serial/reana.yaml
@@ -1,4 +1,3 @@
-version: 0.6.0
 inputs:
   parameters:
     eosdir: root://eospublic.cern.ch//eos/root-eos/HiggsTauTauReduced


### PR DESCRIPTION
Updates content to fit the latest REANA 0.9.1 version commands.

Fixes the bash/output example formatting to fit the latest carpentry style.