### PR TITLE
setup: standardise example formatting

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -10,32 +10,32 @@ This lesson teaches the principles of containerised scientific workflows by mean
 The participants should either install [reana-client](https://pypi.org/project/reana-client/) on
 their laptops:
 
-~~~bash
+```bash
 virtualenv ~/.virtualenvs/reana
 source ~/.virtualenvs/reana/bin/activate
 pip install reana-client
-~~~
+```
 {: .source}
 
 Alternatively, the participants can log into CERN's LXPLUS cluster using `ssh lxplus.cern.ch` and
 activate a pre-existing environment there:
 
-~~~bash
+```bash
 source /afs/cern.ch/user/r/reana/public/reana/bin/activate
-~~~
+```
 {: .source}
 
 After installation of `reana-client`, please check whether the client works by asking for its
 version:
 
-~~~bash
+```bash
 reana-client version
-~~~
+```
 {: .source}
 
-~~~
+```
 0.9.1
-~~~
+```
 {: .output}
 
 ---


### PR DESCRIPTION
Uses three backquotes instead of three tildes for consistency when formatting examples. This style works better in some editors in quoted paragraphs such as Solution sections (where tildes may cause the text to display as strike-through).